### PR TITLE
Config by hostname

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## 0.3.0 (2012-??-??)
+## 0.3.0 (2012-05-22)
 
 This is mostly just a long overdue maintenance release.  Many pull requests were
 merged.  A few non-pull-request branches were merged too.  This version supports

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resque-pool (0.3.0.dev)
+    resque-pool (0.3.0)
       rake
       resque (~> 1.20)
       trollop (~> 1.16)

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -97,7 +97,7 @@ module Resque
         @config ||= {}
       end
       environment and @config[environment] and config.merge!(@config[environment])
-      hostname = Socket.gethostname
+      hostname = (Socket.gethostname rescue nil)
       hostname and @config[hostname] and config.merge!(@config[hostname])
       config.delete_if {|key, value| value.is_a? Hash }
     end

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -6,6 +6,7 @@ require 'resque/pool/logging'
 require 'resque/pool/pooled_worker'
 require 'fcntl'
 require 'yaml'
+require 'socket'
 
 module Resque
   class Pool
@@ -96,6 +97,8 @@ module Resque
         @config ||= {}
       end
       environment and @config[environment] and config.merge!(@config[environment])
+      hostname = Socket.gethostname
+      hostname and @config[hostname] and config.merge!(@config[hostname])
       config.delete_if {|key, value| value.is_a? Hash }
     end
 

--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.3.0.dev"
+    VERSION = "0.3.0"
   end
 end

--- a/man/resque-pool.1
+++ b/man/resque-pool.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "RESQUE\-POOL" "1" "May 2012" "RESQUE-POOL 0.3.0.DEV" "RESQUE-POOL"
+.TH "RESQUE\-POOL" "1" "May 2012" "RESQUE-POOL 0.3.0" "RESQUE-POOL"
 .
 .SH "NAME"
 \fBresque\-pool\fR \- resque worker pool management

--- a/man/resque-pool.yml.5
+++ b/man/resque-pool.yml.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "RESQUE\-POOL\.YML" "5" "May 2012" "RESQUE-POOL 0.3.0.DEV" "RESQUE-POOL"
+.TH "RESQUE\-POOL\.YML" "5" "May 2012" "RESQUE-POOL 0.3.0" "RESQUE-POOL"
 .
 .SH "NAME"
 \fBresque\-pool\.yml\fR \- resque\-pool pool configuration


### PR DESCRIPTION
this enables by-hostname configuration for resque-pool.
environment variables can still be used as usual.

example
<pre>
general_job1: 1
general_job2: 1

staging:
    staging_worker: 1

workers-production-1:
    can_only_be_run_once: 1
    generic_worker: 5

workers-production-2:
    generic_worker: 10
</pre>