### PR TITLE
Pass worker instance to after_prefork hook

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -31,7 +31,7 @@ module Resque
     # The `after_prefork` hooks will be run in workers if you are using the
     # preforking master worker to save memory. Use these hooks to reload
     # database connections and so forth to ensure that they're not shared
-    # among workers.
+    # among workers. The worker instance is passed as an argument to the block.
     #
     # Call with a block to set a hook.
     # Call with no arguments to return all registered hooks.
@@ -49,9 +49,9 @@ module Resque
       @after_prefork = [after_prefork]
     end
 
-    def call_after_prefork!
+    def call_after_prefork!(worker)
       self.class.after_prefork.each do |hook|
-        hook.call
+        hook.call(worker)
       end
     end
 
@@ -398,7 +398,7 @@ module Resque
       pid = fork do
         Process.setpgrp unless Resque::Pool.single_process_group
         log_worker "Starting worker #{worker}"
-        call_after_prefork!
+        call_after_prefork!(worker)
         reset_sig_handlers!
         #self_pipe.each {|io| io.close }
         worker.work(ENV['INTERVAL'] || DEFAULT_WORKER_INTERVAL) # interval, will block

--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -169,11 +169,13 @@ end
 describe Resque::Pool, "given after_prefork hook" do
   subject { Resque::Pool.new(nil) }
 
+  let(:worker) { double }
+
   context "with a single hook" do
     before { Resque::Pool.after_prefork { @called = true } }
 
     it "should call prefork" do
-      subject.call_after_prefork!
+      subject.call_after_prefork!(worker)
       @called.should == true
     end
   end
@@ -182,7 +184,7 @@ describe Resque::Pool, "given after_prefork hook" do
     before { Resque::Pool.after_prefork = Proc.new { @called = true } }
 
     it "should call prefork" do
-      subject.call_after_prefork!
+      subject.call_after_prefork!(worker)
       @called.should == true
     end
   end
@@ -194,9 +196,16 @@ describe Resque::Pool, "given after_prefork hook" do
     }
 
     it "should call both" do
-      subject.call_after_prefork!
+      subject.call_after_prefork!(worker)
       @called_first.should == true
       @called_second.should == true
     end
+  end
+
+  it "passes the worker instance to the hook" do
+    val = nil
+    Resque::Pool.after_prefork { |w| val = w }
+    subject.call_after_prefork!(worker)
+    val.should == worker
   end
 end


### PR DESCRIPTION
This allows the hook to respond based on e.g. which queues the worker is
running.