### PR TITLE
Adding support for wildcard keys.

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -116,6 +116,8 @@ module Resque
     def load_config
       if config_file
         @config = YAML.load(ERB.new(IO.read(config_file)).result)
+
+        add_wildcard_configuration
       else
         @config ||= {}
       end
@@ -422,5 +424,33 @@ module Resque
 
     # }}}
 
+    private
+    def wildcard_keys
+      config_keys_with_wildcard.collect do |wildcard_key|
+        wildcard_key_name = wildcard_key.split('*').first
+        resque_queues_matching_wildcard_key = ::Resque.queues.select { |queue| queue.include?(wildcard_key_name) }
+      end.flatten
+    end
+
+    def config_keys_with_wildcard
+      config.keys.select { |key| key.include?('*') }
+    end
+
+    def config_hash_for_wildcard_keys
+      hash = {}
+
+      wildcard_keys.each do |wildcard_key|
+        hash[wildcard_key] = 1
+      end
+
+      hash
+    end
+
+    def add_wildcard_configuration
+      unless config_keys_with_wildcard.empty?
+        config.merge! config_hash_for_wildcard_keys
+        config_keys_with_wildcard.each { |key| config.except!(key) }
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull requests adds the ability to use a wildcard key.

For Example: a key "queue*" will spin up a worker for each matching queue in Resque.queues. So, if the application has queued up jobs on queues queue1, queue2 and queue3, a worker will be created for each of those queues.