### PR TITLE
Better TERM_CHILD default handling for Heroku

### DIFF
--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -1,10 +1,13 @@
 require 'trollop'
 require 'resque/pool'
+require 'resque/pool/logging'
 require 'fileutils'
 
 module Resque
   class Pool
     module CLI
+      include Logging
+      extend  Logging
       extend self
 
       def run
@@ -113,6 +116,12 @@ where [options] are:
           Resque::Pool.term_behavior = "graceful_worker_shutdown_and_wait"
         elsif opts[:term_graceful]
           Resque::Pool.term_behavior = "graceful_worker_shutdown"
+        elsif ENV["TERM_CHILD"]
+          log "TERM_CHILD enabled, so will user 'term-graceful-and-wait' behaviour"
+          Resque::Pool.term_behavior = "graceful_worker_shutdown_and_wait"
+        end
+        if ENV.include?("DYNO") && !ENV["TERM_CHILD"]
+          log "WARNING: Are you running on Heroku? You should probably set TERM_CHILD=1"
         end
       end
 


### PR DESCRIPTION
- If TERM_CHILD is set, then default to graceful-wait behaviour,
  which seems to be what Heroku expects.
- Allow override via --term-graceful or --term-graceful-wait, which
  also both respect TERM_CHILD and pass TERM to workers when that's set.
- Log the signal we are sending to children, for extra peace of mind.
- Log a warning if it looks like we are running on Heroku and TERM_CHILD
  is not set.
Fixes #98 and #97