### PR TITLE
Add option to spawn missing workers with delay

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -59,7 +59,7 @@ module Resque
     # Config: class methods to start up the pool using the default config {{{
 
     @config_files = ["resque-pool.yml", "config/resque-pool.yml"]
-    class << self; attr_accessor :config_files, :app_name; end
+    class << self; attr_accessor :config_files, :app_name, :spawn_delay; end
 
     def self.app_name
       @app_name ||= File.basename(Dir.pwd)
@@ -375,6 +375,7 @@ module Resque
     def spawn_missing_workers_for(queues)
       worker_delta_for(queues).times do |nr|
         spawn_worker!(queues)
+        sleep Resque::Pool.spawn_delay if Resque::Pool.spawn_delay
       end
     end
 

--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -38,6 +38,7 @@ where [options] are:
           opt :nosync, "Don't sync logfiles on every write"
           opt :pidfile, "PID file location",         :type => String,    :short => "-p"
           opt :environment, "Set RAILS_ENV/RACK_ENV/RESQUE_ENV", :type => String, :short => "-E"
+          opt :spawn_delay, "Delay in milliseconds between spawning missing workers", :type => Integer, :short => "-s"
           opt :term_graceful_wait, "On TERM signal, wait for workers to shut down gracefully"
           opt :term_graceful,      "On TERM signal, shut down workers gracefully"
           opt :term_immediate,     "On TERM signal, shut down workers immediately (default)"
@@ -113,6 +114,9 @@ where [options] are:
           Resque::Pool.term_behavior = "graceful_worker_shutdown_and_wait"
         elsif opts[:term_graceful]
           Resque::Pool.term_behavior = "graceful_worker_shutdown"
+        end
+        if opts[:spawn_delay]
+          Resque::Pool.spawn_delay = opts[:spawn_delay] * 0.001
         end
       end
 


### PR DESCRIPTION
We're running a dozen of servers with resque-pool managing resque workers, and there is one issue that happens from time to time causing us trouble. This pull request addresses it.

When resque workers break on startup (i.e. bad code was deployed), resque-pool goes into a loop that keeps respawning dead workers, putting the server under very heavy load. `spawn_delay` option would add a delay before respawning every missing worker and should keep CPU from redlining when resque workers fail to start.