### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.2
 script: bundle exec rake


### PR DESCRIPTION
Would be great to know that Ruby 2.1.2 is supported.