### PR TITLE
Pass ENV['RUN_AT_EXIT_HOOKS'] to Resque worker

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -411,6 +411,7 @@ module Resque
       worker = ::Resque::Worker.new(*queues)
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']
+      worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS'] || false
       if ENV['LOGGING'] || ENV['VERBOSE']
         worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       end


### PR DESCRIPTION
This is a fix for #106.

It came from the necessity of having BugSnag notifications working correctly with Resque Pool.