### PR TITLE
Bringing back master pid detection, to fix docker

### DIFF
--- a/lib/resque/pool/pooled_worker.rb
+++ b/lib/resque/pool/pooled_worker.rb
@@ -2,14 +2,26 @@ require 'resque/worker'
 
 class Resque::Pool
   module PooledWorker
-    def shutdown_with_pool
-      shutdown_without_pool || Process.ppid == 1
+
+    def initialize_with_pool(*args)
+      @pool_master_pid = Process.pid
+      initialize_without_pool(*args)
+    end
+
+    def pool_master_has_gone_away?
+      @pool_master_pid && @pool_master_pid != Process.ppid
+    end
+
+    def shutdown_with_pool?
+      shutdown_without_pool? || pool_master_has_gone_away?
     end
 
     def self.included(base)
       base.instance_eval do
-        alias_method :shutdown_without_pool, :shutdown?
-        alias_method :shutdown?, :shutdown_with_pool
+        alias_method :initialize_without_pool, :initialize
+        alias_method :initialize, :initialize_with_pool
+        alias_method :shutdown_without_pool?, :shutdown?
+        alias_method :shutdown?, :shutdown_with_pool?
       end
     end
 


### PR DESCRIPTION
Fixes #116

This is fairly ugly, because of the `alias_method` of initialize... if you have any suggestions on how to fix it a different way, I can try something else.  Tested and works for me though, and most importantly, fixes the problem with using resque-pool in a docker env.