### PR TITLE
Reopening log files now reopens all logs in memory

### DIFF
--- a/lib/resque/pool/logging.rb
+++ b/lib/resque/pool/logging.rb
@@ -3,35 +3,76 @@ module Resque
     module Logging
       extend self
 
-      # more than a little bit complicated...
-      # copied this from Unicorn.
+      # This reopens ALL logfiles in the process that have been rotated
+      # using logrotate(8) (without copytruncate) or similar tools.
+      # A +File+ object is considered for reopening if it is:
+      #   1) opened with the O_APPEND and O_WRONLY flags
+      #   2) the current open file handle does not match its original open path
+      #   3) unbuffered (as far as userspace buffering goes, not O_SYNC)
+      # Returns the number of files reopened
+      #
+      # This was mostly copied from Unicorn 4.8.2 to simplify reopening
+      # logs in the same way that Unicorn does.  Original comments and 
+      # explanations are left intact.
       def self.reopen_logs!
-        log "Flushing logs"
-        [$stdout, $stderr].each do |fd|
-          if fd.instance_of? File
-            # skip if the file is the exact same inode and device
-            orig_st = fd.stat
-            begin
-              cur_st = File.stat(fd.path)
-              next if orig_st.ino == cur_st.ino && orig_st.dev == cur_st.dev
-            rescue Errno::ENOENT
+        to_reopen      = [ ]
+        reopened_count = 0
+
+        ObjectSpace.each_object(File) { |fp| is_log?(fp) and to_reopen << fp }
+        log "Flushing #{to_reopen.length} logs"
+
+        to_reopen.each do |fp|
+          orig_st = begin
+            fp.stat
+          rescue IOError, Errno::EBADF # race
+            next
+          end
+
+          begin
+            b = File.stat(fp.path)
+            # Skip if reopening wouldn't do anything
+            next if orig_st.ino == b.ino && orig_st.dev == b.dev
+          rescue Errno::ENOENT
+          end
+
+          begin
+            # stdin, stdout, stderr are special.  The following dance should
+            # guarantee there is no window where `fp' is unwritable in MRI
+            # (or any correct Ruby implementation).
+            #
+            # Fwiw, GVL has zero bearing here.  This is tricky because of
+            # the unavoidable existence of stdio FILE * pointers for
+            # std{in,out,err} in all programs which may use the standard C library
+            if fp.fileno <= 2
+              # We do not want to hit fclose(3)->dup(2) window for std{in,out,err}
+              # MRI will use freopen(3) here internally on std{in,out,err}
+              fp.reopen(fp.path, "a")
+            else
+              # We should not need this workaround, Ruby can be fixed:
+              #    http://bugs.ruby-lang.org/issues/9036
+              # MRI will not call call fclose(3) or freopen(3) here
+              # since there's no associated std{in,out,err} FILE * pointer
+              # This should atomically use dup3(2) (or dup2(2)) syscall
+              File.open(fp.path, "a") { |tmpfp| fp.reopen(tmpfp) }
             end
-            # match up the encoding
-            open_arg = 'a'
-            if fd.respond_to?(:external_encoding) && enc = fd.external_encoding
-              open_arg << ":#{enc.to_s}"
-              enc = fd.internal_encoding and open_arg << ":#{enc.to_s}"
+
+            fp.sync = true
+            fp.flush # IO#sync=true may not implicitly flush
+            new_st = fp.stat
+
+            # this should only happen in the master:
+            if orig_st.uid != new_st.uid || orig_st.gid != new_st.gid
+              fp.chown(orig_st.uid, orig_st.gid)
             end
-            # match up buffering (does reopen reset this?)
-            sync = fd.sync
-            # sync to disk
-            fd.fsync
-            # reopen, and set ruby buffering appropriately
-            fd.reopen fd.path, open_arg
-            fd.sync = sync
-            log "Reopened logfile: #{fd.path}"
+
+            log "Reopened logfile: #{fp.path}"
+            reopened_count += 1
+          rescue IOError, Errno::EBADF
+            # not much we can do...
           end
         end
+
+        reopened_count
       end
 
       # Given a string, sets the procline ($0)
@@ -43,12 +84,14 @@ module Resque
 
       # TODO: make this use an actual logger
       def log(message)
+        return if $skip_logging
         puts "resque-pool-manager#{app}[#{Process.pid}]: #{message}"
         #$stdout.fsync
       end
 
       # TODO: make this use an actual logger
       def log_worker(message)
+        return if $skip_logging
         puts "resque-pool-worker#{app}[#{Process.pid}]: #{message}"
         #$stdout.fsync
       end
@@ -58,6 +101,20 @@ module Resque
         app_name   = self.respond_to?(:app_name)       && self.app_name
         app_name ||= self.class.respond_to?(:app_name) && self.class.app_name
         app_name ? "[#{app_name}]" : ""
+      end
+
+      private
+
+      # Used by reopen_logs, borrowed from Unicorn...
+      def self.is_log?(fp)
+        append_flags = File::WRONLY | File::APPEND
+
+        ! fp.closed? &&
+          fp.stat.file? &&
+          fp.sync &&
+          (fp.fcntl(Fcntl::F_GETFL) & append_flags) == append_flags
+        rescue IOError, Errno::EBADF
+          false
       end
 
     end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe Resque::Pool::Logging do
+
+  let(:expect_flags) { File::WRONLY | File::APPEND }
+  
+  # Don't pollute the log output
+  before(:all) { $skip_logging = true }
+  after(:all) { $skip_logging = false }
+
+  context "when reopening logs" do
+
+    before(:each) do
+      @tmp     = Tempfile.new('')
+      @fp      = File.open(@tmp.path, 'ab')
+      @fp.sync = true
+      @ext     = @fp.external_encoding rescue nil
+      @int     = @fp.internal_encoding rescue nil
+      @before  = @fp.stat.inspect
+    end
+
+    after(:each) do
+      @tmp.close!
+      @fp.close
+    end
+
+    it "reopens logs noop" do
+      Resque::Pool::Logging.reopen_logs!.should == 0
+
+      @before.should == File.stat(@fp.path).inspect
+      @ext.should == (@fp.external_encoding rescue nil)
+      @int.should == (@fp.internal_encoding rescue nil)
+      expect_flags.should == (expect_flags & @fp.fcntl(Fcntl::F_GETFL))
+    end
+
+    it "reopens renamed logs" do
+      tmp_path = @tmp.path.freeze
+      to = Tempfile.new('')
+      File.rename(tmp_path, to.path)
+      File.exist?(tmp_path).should be_falsey
+
+      Resque::Pool::Logging.reopen_logs!.should == 1
+
+      tmp_path.should == @tmp.path
+      File.exist?(tmp_path).should be_truthy
+      @before.should_not == File.stat(tmp_path).inspect
+      @fp.stat.inspect.should == File.stat(tmp_path).inspect
+      @ext.should == (@fp.external_encoding rescue nil)
+      @int.should == (@fp.internal_encoding rescue nil)
+      expect_flags.should == (expect_flags & @fp.fcntl(Fcntl::F_GETFL))
+      @fp.sync.should be_truthy
+
+      to.close!
+    end
+  end
+
+  context "when reopening logs with external encoding" do
+    before(:each) do
+      @tmp      = Tempfile.new('')
+      @tmp_path = @tmp.path.dup.freeze
+    end
+
+    after(:each) do
+      @tmp.close!
+    end
+
+    it "reopens logs renamed with encoding" do
+      Encoding.list.each do |encoding|
+        File.open(@tmp_path, "a:#{encoding.to_s}") do |fp|
+          fp.sync = true
+          encoding.should == fp.external_encoding
+          fp.internal_encoding.should be_nil
+          File.unlink(@tmp_path)
+          File.exist?(@tmp_path).should be_falsey
+          Resque::Pool::Logging.reopen_logs!
+          
+          @tmp_path.should == fp.path
+          File.exist?(@tmp_path).should be_truthy
+          fp.stat.inspect.should == File.stat(@tmp_path).inspect
+          encoding.should == fp.external_encoding
+          fp.internal_encoding.should be_nil
+          expect_flags.should == (expect_flags & fp.fcntl(Fcntl::F_GETFL))
+          fp.sync.should be_truthy
+        end
+      end
+    end if STDIN.respond_to?(:external_encoding)
+
+    # This spec can take a while to run through all of the encodings...
+    it "reopens logs renamed with internal encoding" do
+      Encoding.list.each do |ext|
+        Encoding.list.each do |int|
+          next if ext == int
+          File.open(@tmp_path, "a:#{ext.to_s}:#{int.to_s}") do |fp|
+            fp.sync = true
+            ext.should == fp.external_encoding
+
+            if ext != Encoding::BINARY
+              int.should == fp.internal_encoding
+            end
+
+            File.unlink(@tmp_path)
+            File.exist?(@tmp_path).should be_falsey
+            Resque::Pool::Logging.reopen_logs!
+
+            @tmp_path.should == fp.path
+            File.exist?(@tmp_path).should be_truthy
+            fp.stat.inspect.should == File.stat(@tmp_path).inspect
+            ext.should == fp.external_encoding
+
+            if ext != Encoding::BINARY
+              int.should == fp.internal_encoding
+            end
+
+            expect_flags.should == (expect_flags & fp.fcntl(Fcntl::F_GETFL))
+            fp.sync.should be_truthy
+          end
+        end
+      end
+    end if STDIN.respond_to?(:external_encoding)
+
+  end
+
+end


### PR DESCRIPTION
As per Issue #30 I've ported Unicorn's code for reopening log files to resque-pool.

A few notes:
1. I haven't yet tested this in production myself.  I plan on getting it in today or this weekend.
2. I ported over all of Unicorn's tests for re-opening log files to RSpec.  The last one that tests encodings takes a while to run.
3. I added a few more additional checks to make sure that the reopening mechanism is working as expected.

On my development machine, things appear to be working as expected when I send a HUP to the resque-pool master.

