### PR TITLE
kick out trollop

### DIFF
--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   EOF
 
   s.add_dependency "resque",  "~> 1.22"
-  s.add_dependency "trollop", "~> 2.0"
   s.add_dependency "rake"
   s.add_development_dependency "rspec",    "~> 2.10"
   s.add_development_dependency "cucumber", "~> 1.2"


### PR DESCRIPTION
1 less dependency and gives a little bit more fine-grained control :)

@nevans 

before:
```
./bin/resque-pool -h
resque-pool is the best way to manage a group (pool) of resque workers

When daemonized, stdout and stderr default to resque-pool.stdxxx.log files in
the log directory and pidfile defaults to resque-pool.pid in the current dir.

Usage:
   resque-pool [options]
where [options] are:
  -c, --config=<s>              Alternate path to config file
  -a, --appname=<s>             Alternate appname
  -d, --daemon                  Run as a background daemon
  -o, --stdout=<s>              Redirect stdout to logfile
  -e, --stderr=<s>              Redirect stderr to logfile
  -n, --nosync                  Don't sync logfiles on every write
  -p, --pidfile=<s>             PID file location
  -E, --environment=<s>         Set RAILS_ENV/RACK_ENV/RESQUE_ENV
  -s, --spawn-delay=<i>         Delay in milliseconds between spawning missing workers
  -t, --term-graceful-wait      On TERM signal, wait for workers to shut down gracefully
  -r, --term-graceful           On TERM signal, shut down workers gracefully
  -m, --term-immediate          On TERM signal, shut down workers immediately (default)
  -i, --single-process-group    Workers remain in the same process group as the master
  -v, --version                 Print version and exit
  -h, --help                    Show this message
```


after:
```
/bin/resque-pool -h
resque-pool is the best way to manage a group (pool) of resque workers

When daemonized, stdout and stderr default to resque-pool.stdxxx.log files in
the log directory and pidfile defaults to resque-pool.pid in the current dir.

Usage:
   resque-pool [options]

where [options] are:
    -c, --config PATH                Alternate path to config file
    -a, --appname NAME               Alternate appname
    -d, --daemon                     Run as a background daemon
    -o, --stdout FILE                Redirect stdout to logfile
    -e, --stderr FILE                Redirect stderr to logfile
        --nosync                     Don't sync logfiles on every write
    -p, --pidfile FILE               PID file location
    -E, --environment ENVIRONMENT    Set RAILS_ENV/RACK_ENV/RESQUE_ENV
    -s, --spawn-delay MS             Delay in milliseconds between spawning missing workers
        --term-graceful-wait         On TERM signal, wait for workers to shut down gracefully
        --term-graceful              On TERM signal, shut down workers gracefully
        --term-immediate             On TERM signal, shut down workers immediately (default)
        --single-process-group       Workers remain in the same process group as the master
    -h, --help                       Show this.
    -v, --version                    Show Version
```