### PR TITLE
Option to kill other resque-pool instances on startup

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -88,6 +88,11 @@ module Resque
       @handle_winch = bool
     end
 
+    def self.kill_other_pools!
+      require 'resque/pool/killer'
+      Resque::Pool::Killer.run
+    end
+
     def self.single_process_group=(bool)
       ENV["RESQUE_SINGLE_PGRP"] = !!bool ? "YES" : "NO"
     end
@@ -98,6 +103,7 @@ module Resque
     end
 
     def self.run
+      kill_other_pools! if kill_other_pools
       if GC.respond_to?(:copy_on_write_friendly=)
         GC.copy_on_write_friendly = true
       end
@@ -235,6 +241,7 @@ module Resque
 
     class << self
       attr_accessor :term_behavior
+      attr_accessor :kill_other_pools
     end
 
     def graceful_worker_shutdown_and_wait!(signal)

--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -37,6 +37,7 @@ module Resque
           opt.on('-c', '--config PATH', "Alternate path to config file") { |c| opts[:config] = c }
           opt.on('-a', '--appname NAME', "Alternate appname") { |c| opts[:appname] = c }
           opt.on("-d", '--daemon', "Run as a background daemon") { opts[:daemon] = true }
+          opt.on("-k", '--kill-others', "Shutdown any other Resque Pools on startup") { opts[:killothers] = true }
           opt.on('-o', '--stdout FILE', "Redirect stdout to logfile") { |c| opts[:stdout] = c }
           opt.on('-e', '--stderr FILE', "Redirect stderr to logfile") { |c| opts[:stderr] = c }
           opt.on('--nosync', "Don't sync logfiles on every write") { opts[:nosync] = true }
@@ -130,6 +131,7 @@ module Resque
         if opts[:spawn_delay]
           Resque::Pool.spawn_delay = opts[:spawn_delay] * 0.001
         end
+        Resque::Pool.kill_other_pools = !!opts[:killothers]
       end
 
       def setup_environment(opts)

--- a/lib/resque/pool/killer.rb
+++ b/lib/resque/pool/killer.rb
@@ -1,0 +1,41 @@
+require 'open3'
+
+module Resque
+  class Pool
+    class Killer
+      include Logging
+
+      GRACEFUL_SHUTDOWN_SIGNAL=:INT
+
+      def self.run
+        new.run
+      end
+
+      def run
+        my_pid = Process.pid
+        pool_pids = all_resque_pool_processes
+        pids_to_kill = pool_pids.reject{|pid| pid == my_pid}
+        pids_to_kill.each do |pid|
+          log "Pool (#{my_pid}) in kill-others mode: killing pool with pid (#{pid})"
+          Process.kill(GRACEFUL_SHUTDOWN_SIGNAL, pid)
+        end
+      end
+
+
+      def all_resque_pool_processes
+        out, err, status = Open3.capture3("ps ax")
+        unless status.success?
+          raise "Unable to identify other pools: #{err}"
+        end
+        parse_pids_from_output out
+      end
+
+      def parse_pids_from_output(output)
+        pool_lines = output.split("\n").grep(/resque-pool-master/)
+        pool_lines.map{|line|
+          line.split.first.to_i
+        }.select{|pid| pid > 0}
+      end
+    end
+  end
+end

--- a/lib/resque/pool/logging.rb
+++ b/lib/resque/pool/logging.rb
@@ -75,11 +75,13 @@ module Resque
         reopened_count
       end
 
+      PROCLINE_PREFIX="resque-pool-master"
+
       # Given a string, sets the procline ($0)
       # Procline is always in the format of:
       #   resque-pool-master: STRING
       def procline(string)
-        $0 = "resque-pool-master#{app}: #{string}"
+        $0 = "#{PROCLINE_PREFIX}#{app}: #{string}"
       end
 
       # TODO: make this use an actual logger

--- a/spec/killer_spec.rb
+++ b/spec/killer_spec.rb
@@ -11,31 +11,32 @@ describe Resque::Pool::Killer do
   end
 
   PS_OUTPUT= <<END
- 6472 ?        S      0:00 hald-addon-acpi: listening on acpid socket /var/run/acpid.socket
- 6502 ?        Sl     2:51 resque-pool-master[demo]: managing [7028, 7034]
- 6511 ?        Ss     0:00 xinetd -stayalive -pidfile /var/run/xinetd.pid
- 6539 pts/18   Sl+    0:31 ruby /var/www/shipit/shared/bundle/ruby/2.1.0/bin/rails console
-20971 ?        Sl    91:51 resque-1.25.2: Waiting for ecwid
-14817 pts/15   Ss     0:00 -bash
-16334 ?        Ss     0:00 sshd: foo [priv]
-16336 ?        S      0:00 sshd: foo@pts/0
-16337 pts/0    Ss     0:00 -bash
-16342 pts/7    S+     0:00 /bin/bash /usr/local/bin/console
-16480 pts/7    Sl+    0:30 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
-16486 pts/0    R+     0:00 ps ax
-16800 ?        Sl     5:21 resque-pool-master[demo]: managing [20728, 20734]
-17239 pts/19   Ss     0:00 -bash
-17407 pts/19   S+     0:00 /bin/bash /usr/local/bin/console
-17549 pts/19   Sl+    3:37 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
-18027 ?        Ss     0:00 rpc.statd -p 32765 -o 32766
-18114 ?        S<sl  15:32 auditd
-19536 ?        Sl     2:05 resque-scheduler-4.0.0[production]: Processing Delayed Items
-20004 pts/9    Ss     0:00 -bash
-20728 ?        Sl   165:24 resque-1.25.2: Waiting for queuea,queueb
-20734 ?        Sl   164:55 resque-1.25.2: Waiting for queueb,queuea
-20799 pts/10   S+     0:00 /bin/bash /usr/local/bin/console
-20959 pts/10   Sl+    0:31 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
-20967 ?        Sl   332:07 resque-1.25.2: queuec,queued,*
+ 6472 hald-addon-acpi: listening on acpid socket /var/run/acpid.socket
+ 6502 resque-pool-master[demo]: managing [7028, 7034]
+ 6511 xinetd -stayalive -pidfile /var/run/xinetd.pid
+ 6539 ruby /var/www/shipit/shared/bundle/ruby/2.1.0/bin/rails console
+20971 resque-1.25.2: Waiting for ecwid
+14817 -bash
+16334 sshd: foo [priv]
+16336 sshd: foo@pts/0
+16337 -bash
+16342 /bin/bash /usr/local/bin/console
+16480 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
+16486 ps ax
+16800 resque-pool-master[demo]: managing [20728, 20734]
+17239 -bash
+17407 /bin/bash /usr/local/bin/console
+17408 grep resque-pool-master
+17549 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
+18027 rpc.statd -p 32765 -o 32766
+18114 auditd
+19536 resque-scheduler-4.0.0[production]: Processing Delayed Items
+20004 -bash
+20728 resque-1.25.2: Waiting for queuea,queueb
+20734 resque-1.25.2: Waiting for queueb,queuea
+20799 /bin/bash /usr/local/bin/console
+20959 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
+20967 resque-1.25.2: queuec,queued,*
 END
 
 end

--- a/spec/killer_spec.rb
+++ b/spec/killer_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'resque/pool/killer'
+
+describe Resque::Pool::Killer do
+  subject(:killer) { Resque::Pool::Killer.new }
+  describe "parse pids from output" do
+    it "returns the first column, as integer, for resque pool processes" do
+      pids = killer.parse_pids_from_output(PS_OUTPUT)
+      pids.should match_array [6502, 16800]
+    end
+  end
+
+  PS_OUTPUT= <<END
+ 6472 ?        S      0:00 hald-addon-acpi: listening on acpid socket /var/run/acpid.socket
+ 6502 ?        Sl     2:51 resque-pool-master[demo]: managing [7028, 7034]
+ 6511 ?        Ss     0:00 xinetd -stayalive -pidfile /var/run/xinetd.pid
+ 6539 pts/18   Sl+    0:31 ruby /var/www/shipit/shared/bundle/ruby/2.1.0/bin/rails console
+20971 ?        Sl    91:51 resque-1.25.2: Waiting for ecwid
+14817 pts/15   Ss     0:00 -bash
+16334 ?        Ss     0:00 sshd: foo [priv]
+16336 ?        S      0:00 sshd: foo@pts/0
+16337 pts/0    Ss     0:00 -bash
+16342 pts/7    S+     0:00 /bin/bash /usr/local/bin/console
+16480 pts/7    Sl+    0:30 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
+16486 pts/0    R+     0:00 ps ax
+16800 ?        Sl     5:21 resque-pool-master[demo]: managing [20728, 20734]
+17239 pts/19   Ss     0:00 -bash
+17407 pts/19   S+     0:00 /bin/bash /usr/local/bin/console
+17549 pts/19   Sl+    3:37 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
+18027 ?        Ss     0:00 rpc.statd -p 32765 -o 32766
+18114 ?        S<sl  15:32 auditd
+19536 ?        Sl     2:05 resque-scheduler-4.0.0[production]: Processing Delayed Items
+20004 pts/9    Ss     0:00 -bash
+20728 ?        Sl   165:24 resque-1.25.2: Waiting for queuea,queueb
+20734 ?        Sl   164:55 resque-1.25.2: Waiting for queueb,queuea
+20799 pts/10   S+     0:00 /bin/bash /usr/local/bin/console
+20959 pts/10   Sl+    0:31 ruby /var/www/foo/shared/bundle/ruby/2.1.0/bin/rails console
+20967 ?        Sl   332:07 resque-1.25.2: queuec,queued,*
+END
+
+end


### PR DESCRIPTION
Adds the `--kill-others` command line option.
When this option is set, resque-pool will send a graceful
shutdown signal to all other running resque-pools.

This is useful in "no downtime deploy" scenarios,
where you want the pool running the new code to
completely load its environment and be ready to
process work *before* shutting down the old code.
Once the new code is ready, it will shut down the
old processes for you.

See also https://github.com/nevans/resque-pool/pull/132