### PR TITLE
Make `rake spec` fast again

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,14 @@ require 'bundler/gem_tasks'
 require 'resque/pool/tasks'
 
 require 'rspec/core/rake_task'
+
+desc "Run fast RSpec code examples"
 RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = ["-c", "-f progress", "--tag ~slow"]
+end
+
+desc "Run all RSpec code examples"
+RSpec::Core::RakeTask.new("spec:ci") do |t|
   t.rspec_opts = ["-c", "-f progress"]
 end
 
@@ -14,7 +21,7 @@ Cucumber::Rake::Task.new(:features) do |c|
   c.profile = "rake"
 end
 
-task :default => [:spec, :features]
+task :default => ["spec:ci", :features]
 
 rule(/\.[1-9]$/ => [proc { |tn| "#{tn}.ronn" }]) do |t|
   name = Resque::Pool.name.sub('::','-').upcase

--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "resque", "~> 1.22"
   s.add_dependency "rake"
-  s.add_development_dependency "rspec",    "~> 2.10"
+  s.add_development_dependency "rspec",    "~> 2.99"
   s.add_development_dependency "cucumber", "~> 1.2"
   s.add_development_dependency "aruba",    "~> 0.4.11"
   s.add_development_dependency "ronn"

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -87,7 +87,7 @@ describe Resque::Pool::Logging do
     end if STDIN.respond_to?(:external_encoding)
 
     # This spec can take a while to run through all of the encodings...
-    it "reopens logs renamed with internal encoding" do
+    it "reopens logs renamed with internal encoding", slow: true do
       Encoding.list.each do |ext|
         Encoding.list.each do |int|
           next if ext == int


### PR DESCRIPTION
`rake spec` had become unbearably slow, with one of the specs that loops over all combinations of input/output encodings. I think we can safely get by with only running that spec during the continuous integration build. I tagged it as `slow` and made the `rake spec` task ignore `slow` specs.

`rake spec:ci` will run all specs. This is what will run in the Travis CI build.

Also updated the rspec version to match the version already used in Travis CI build. This ensures a more consistent experience between dev and CI, and allows using some of the newer rspec features.