### PR TITLE
catch edge cases where old_pid is invalid

### DIFF
--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -120,8 +120,7 @@ module Resque
 
       def process_still_running?(pidfile)
         old_pid = open(pidfile).read.strip.to_i
-        Process.kill 0, old_pid
-        true
+        old_pid > 0 && Process.kill(0, old_pid)
       rescue Errno::ESRCH
         false
       rescue Errno::EPERM


### PR DESCRIPTION
If `pidfile` points to an empty file, or contains non-numeric data`old_pid` will be 0. It's also possible for pidfile to contain '-1'. In both cases `Process.kill` returns 1 on my system, so resque-pool will erroneously think the old process is still running.