### PR TITLE
Fix occasional all_resque_pool_processes deadlock

### DIFF
--- a/lib/resque/pool/killer.rb
+++ b/lib/resque/pool/killer.rb
@@ -1,5 +1,3 @@
-require 'open3'
-
 module Resque
   class Pool
     class Killer
@@ -23,10 +21,8 @@ module Resque
 
 
       def all_resque_pool_processes
-        out, err, status = Open3.capture3("ps -e -o pid= -o command=")
-        unless status.success?
-          raise "Unable to identify other pools: #{err}"
-        end
+        out = `ps -e -o pid= -o command= 2>&1`
+        raise "Unable to identify other pools: #{out}" unless $?.success?
         parse_pids_from_output out
       end
 


### PR DESCRIPTION
`Open3.capture3` is vulnerable to deadlock because it has two threads
doing blocking reads on separate stderr/stdout pipes, each with limited
buffer size.

In this case, we only need stdout to parse the pids. We want stderr in
case the ps command fails. So we get the best of both worlds by
redirecting stderr to stdout, relying on exitstatus to decide whether
the command succeeded, and showing full output if it didn't.