### PR TITLE
Always refresh Resque's redis connection in spawned workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,16 +76,9 @@ task "resque:pool:setup" do
 end
 ```
 
-
-For normal work with fresh resque and resque-scheduler gems add next lines in lib/rake/resque.rake
-
-```ruby
-task "resque:pool:setup" do
-  Resque::Pool.after_prefork do |job|
-    Resque.redis.client.reconnect
-  end
-end
-```
+Note that starting in v0.7.0, Resque pool will automatically reconnect
+`Resque.redis.client` in each master process, so there's no need to do that
+explicitly in the `after_prefork` hook.
 
 ### Start the pool manager
 

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -414,6 +414,7 @@ module Resque
         log_worker "Starting worker #{worker}"
         call_after_prefork!(worker)
         reset_sig_handlers!
+        Resque.redis.client.reconnect
         #self_pipe.each {|io| io.close }
         worker.work(ENV['INTERVAL'] || DEFAULT_WORKER_INTERVAL) # interval, will block
       end


### PR DESCRIPTION
When the initial batch of workers is spawned by the resque-pool master process, the master will not generally be in possession of a Redis connection. However, as soon as one of the workers dies and needs to be respawned, the resque-pool master will establish a Redis connection in order to enumerate the resque queues, via the call to `Worker#queues` in [reap_all_workers](https://github.com/nevans/resque-pool/blob/ec81c92df41ecdbdecaea55863964baf3e9e03ad/lib/resque/pool.rb#L338).

When this happens, the first worker after the initial batch that's spawned by the resque-pool master will inherit resque's Redis connection from the resque-pool master, and will try to use it.

With older versions of the redis-rb gem (pre 3.1.0), or with the inherit_socket option, this will cause an exception in the newly-spawned worker, and make the resque-pool master get into a loop wherein it tries and fails repeatedly to spawn a new worker.

This change ensures that a new Redis connection is always established inside of newly-spawned resque worker processes, avoiding the bad state. While it would be possible to do this manually via an after_prefork hook manually, the manifestation of this problem is pretty non-obvious, because of the fact that it doesn't happen for the first batch of spawned workers, so it seems considerate to do the right thing out of the box, and avoid the unpleasant surprise when a worker dies.
