### PR TITLE
Treat ENV['RESQUE_TERM_TIMEOUT'] as a float

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -425,7 +425,7 @@ module Resque
       queues = queues.to_s.split(',')
       worker = ::Resque::Worker.new(*queues)
       worker.pool_master_pid = Process.pid
-      worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
+      worker.term_timeout = (ENV['RESQUE_TERM_TIMEOUT'] || 4.0).to_f
       worker.term_child = ENV['TERM_CHILD']
       if worker.respond_to?(:run_at_exit_hooks=)
         # resque doesn't support this until 1.24, but we support 1.22


### PR DESCRIPTION
As reported in https://github.com/nevans/resque-pool/issues/162, setting RESQUE_TERM_TIMEOUT in the environment results in a crash on exit because the number is treated as a string.

This is overriding the resque gem's worker.initialize function, which does correctly treat it as a float.