### PR TITLE
Resque::Pool: Cast term timeout from env to float

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -425,7 +425,7 @@ module Resque
       queues = queues.to_s.split(',')
       worker = ::Resque::Worker.new(*queues)
       worker.pool_master_pid = Process.pid
-      worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
+      worker.term_timeout = (ENV['RESQUE_TERM_TIMEOUT'] || 4.0).to_f
       worker.term_child = ENV['TERM_CHILD']
       if worker.respond_to?(:run_at_exit_hooks=)
         # resque doesn't support this until 1.24, but we support 1.22

--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -309,3 +309,27 @@ describe Resque::Pool, "given after_prefork hook" do
     val.should == worker
   end
 end
+
+describe Resque::Pool, "#create_worker" do
+
+  subject { Resque::Pool.new(nil) }
+
+  it "successfully creates a new worker" do
+    worker = subject.create_worker("default")
+
+    expect(worker).to be
+    expect(worker.term_timeout).to eq(4.0)
+  end
+
+  context "with a RESQUER_TERM_TIMEOUT set" do
+    before { ENV["RESQUE_TERM_TIMEOUT"] = "5" }
+
+    it "successfully creates a new worker" do
+
+      worker = subject.create_worker("default")
+
+      expect(worker).to be
+      expect(worker.term_timeout).to eq(5.0)
+    end
+  end
+end


### PR DESCRIPTION
This would otherwise create an error in resque[1] where this value is
multiplied by 10 and would result in the value in the ENV hash
duplicated 10 times as a String.

[1]: https://github.com/resque/resque/blob/cde288ac45cee0e9b52bf27bde57670a1d240fe8/lib/resque/worker.rb#L550