### PR TITLE
allow resque 2.0

### DIFF
--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency "resque", "~> 1.22"
+  s.add_dependency "resque", ">= 1.22", "< 3"
   s.add_dependency "rake"
   s.add_development_dependency "rspec",    "~> 2.99"
   s.add_development_dependency "cucumber", "~> 1.2"


### PR DESCRIPTION
Just changed gemspec to allow resque 2.x. 

Tests still pass for me locally with `bundle exec rspec` -- is that enough to be confident resque 2.0 is no problem?

Ref: #170 