### PR TITLE
Introduce siginfo-hook and SIGINFO 29 signal handling

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -13,7 +13,7 @@ module Resque
   class Pool
     SIG_QUEUE_MAX_SIZE = 5
     DEFAULT_WORKER_INTERVAL = 5
-    QUEUE_SIGS = [ :QUIT, :INT, :TERM, :USR1, :USR2, :CONT, :HUP, :WINCH, ]
+    QUEUE_SIGS = [ :QUIT, :INT, :TERM, :USR1, :USR2, :CONT, :HUP, :WINCH, Signal.signame(29).to_sym ]
     CHUNK_SIZE = (16 * 1024)
 
     include Logging
@@ -63,14 +63,26 @@ module Resque
 
     ##
     # :call-seq:
-    #   after_prefork do |worker, pid, workers| ... end  => add a hook
-    #   after_prefork << hook                            => add a hook
+    #   after_spawn do |worker, pid, workers| ... end  => add a hook
+    #   after_spawn << hook                            => add a hook
     #
     # The `after_spawn` hooks will run in the master after spawning a new
     # worker.
     #
     # :yields: worker, pid, workers
     hook :after_spawn
+
+    ##
+    # :call-seq:
+    #   siginfo do |pool_instance, pid, workers| ... end  => add a hook
+    #   siginfo << hook                                   => add a hook
+    #
+    # The `siginfo` hooks will run in the master after receiving a SIGINFO 29 signal.
+    # A given block will receive the instance of the running manager pool,
+    # the manager pid and the workers hash.
+    #
+    # :yields: pid, workers
+    hook :siginfo
 
     # }}}
     # Config: class methods to start up the pool using the config loader {{{
@@ -235,6 +247,11 @@ module Resque
         else
           shutdown_everything_now!(signal)
         end
+      when Signal.signame(29).to_sym
+        maintain_worker_count
+        Thread.start(self, Process.pid, workers) do |instance, pid, workers|
+          call_siginfo!(instance, pid, workers)
+        end.join
       end
     end
 


### PR DESCRIPTION
Can be used to hook into pool manager (e.g. to report on workers).

<hr>

Sorry for not opening an issue beforehand, maybe we can discuss the utility of this addition here as well.

The main idea behind this addition, is to allow the user of a pool to write some code that runs within the pool manager by request of a signal.
Due to the lack of available signal codes, I have chosen the relatively well fitting Signal 29 SIGINFO also known as SIGPOLL or SIGIO.

In our case, we needed a facility to regularly report the current process pids on long running jobs.
On one side we would store the worker hostname + worker pid when starting the job.
On the other side, we would regularly query the pool manager (with a signal) to report on its running processes.

That way, we are always able to compare the currently running pools + worker pids against the jobs that are reporting to run on a certain pool + worker pid.
If a job went stale, we can safely restart it, because at the time we would restart it, we know the process or pool that was tasked with the job does not exist any more.

Why not handle all of that inside the worker?

That was the first approach, but then any failures of the worker-process itself has led to stale jobs.

Here is some code, how we use the `siginfo`-hook:

```ruby
# in lib/tasks/resque.rake

task "resque:pool:setup" do

  Resque::Pool.siginfo do |pool, _pid, _workers|
    key = "resque:pool:#{Socket.gethostname}"
    # Maintain an accessible set of worker pids,
    # so we know if a worker process died.
    redis = Redis.new(url: ENV['REDIS_URL'])
    redis.multi do |multi|
      multi.del(key)
      multi.sadd(key, pool.all_pids)
      multi.expire(key, 60)
    end
  end

end
```

```ruby
# in our code dealing with a run of a job
# Note: worker_id and worker_pid are stored when the job is created

def retryable?
  pids = redis.smember("resque:pool:#{worker_id}")
  !pids.include?(worker_pid)
end
```
